### PR TITLE
Extend try catch so app doesnt fall over on start

### DIFF
--- a/lib/wii.js
+++ b/lib/wii.js
@@ -72,15 +72,15 @@ function wiiController() {
         device = new HID.HID(d.path)
       }
     }).bind(this))
-    this.hid = device
-
-    for (var key in buttons) {
-      this[key] = 0;
-    }
-    this.states.x = 0;
-    this.states.y = 0;
 
     try{
+      this.hid = device
+
+      for (var key in buttons) {
+        this[key] = 0;
+      }
+      this.states.x = 0;
+      this.states.y = 0;
       this.hid.read(this.interpretData.bind(this));
     }
     catch ( ex ){


### PR DESCRIPTION
Hi

I found my app was falling over if no wiimote was connected because device is not defined, simply extended the try catch block to cover this use case and now works fine

Thanks

Jonathan
